### PR TITLE
Bugfix - endpoints not configured

### DIFF
--- a/lib/abstract-api.js
+++ b/lib/abstract-api.js
@@ -26,9 +26,12 @@ class AbstractAPI {
     setupRoutes(server) {
 
         this._getHttpMethodsMappedToServerFunctions().forEach(httpMethod => {
-            this._getEndpoinsFor(httpMethod.name).forEach(endpoint => {
-                httpMethod.serverFunction(server, endpoint);
-            });
+            const endpointsForHttpMethod = this._getEndpoinsFor(httpMethod.name);
+            if (endpointsForHttpMethod != null && endpointsForHttpMethod.length > 0) {
+                endpointsForHttpMethod.forEach(endpoint => {
+                    httpMethod.serverFunction(server, endpoint);
+                });
+            }
         });
 
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-abstract-config",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Abstract config system for your Restify endpoints",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Didn't check if endpoints exactly exist for a HTTP method before iterating over them.
